### PR TITLE
remove the google tag and use only UA id

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -62,7 +62,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "UA-186940925-1"
 
 [markup]
   [markup.goldmark]

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,15 +1,5 @@
 <script src="{{ "js/script.js" | relURL }}"></script>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-J4CNG4SV92"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-J4CNG4SV92');
-</script>
-
 <style>
 a {
   color: blue;  


### PR DESCRIPTION
The Google Tag did not work as expected.  Reverted to using the UA id only.