### PR TITLE
Dockerfile update for alpine-nginx-pagespeed 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base nginx image
-FROM nginx:alpine
+FROM wernight/alpine-nginx-pagespeed
 
 # an arbitrary directory to build our site in
 WORKDIR /build
@@ -16,6 +16,7 @@ RUN set -x && \
 
 # Hugo extended doesn't run on Alpine https://github.com/gohugoio/hugo/issues/4961
 # Following https://github.com/dettmering/hugo-build/blob/3275b1c4eb90abf7f5cab7107f7e6c894eb74505/Dockerfile
+# and https://github.com/sgerrand/alpine-pkg-glibc
 # Install glibc
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
@@ -38,6 +39,14 @@ RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${H
   apk del wget ca-certificates && \
   rm /var/cache/apk/*
 
+# Configure pagespeed
+
+RUN mv conf/pagespeed.conf /etc/nginx/ && \
+    mv conf/nginx.conf /etc/nginx && \
+    mkdir -p /tmp/pagespeed_cache && \
+    # fix /tmp/pagespeed_cache permission denied
+    chmod a+w /tmp/pagespeed_cache
+
 # Move site content to nginx
 
-RUN cp -fR /build/public/* /usr/share/nginx/html
+RUN cp -fR /build/public/* /etc/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,15 @@ WORKDIR /build
 # copy the project into the container
 COPY . .
 
-# download hugo and make it available in PATH
 ENV HUGO_VERSION 0.81.0
 ENV HUGO_BINARY hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
-
 ENV GLIBC_VERSION 2.23-r3
 
 RUN set -x && \
   apk add --update wget ca-certificates libstdc++
 
+# Hugo extended doesn't run on Alpine https://github.com/gohugoio/hugo/issues/4961
+# Following https://github.com/dettmering/hugo-build/blob/3275b1c4eb90abf7f5cab7107f7e6c894eb74505/Dockerfile
 # Install glibc
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
@@ -29,7 +29,7 @@ RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/s
 &&  apk --no-cache add glibc-i18n-${GLIBC_VERSION}.apk \
 &&  rm glibc-i18n-${GLIBC_VERSION}.apk
 
-# Install HUGO
+# Install HUGO and make it available in PATH
 
 RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} && \
   tar xzf ${HUGO_BINARY} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,43 @@
-FROM klakegg/hugo:ext-alpine
+# base nginx image
+FROM nginx:alpine
 
-COPY . /src
+# an arbitrary directory to build our site in
+WORKDIR /build
 
-EXPOSE 1313
-WORKDIR /src
+# copy the project into the container
+COPY . .
 
-ENV HUGO_ENV production
-ENTRYPOINT ["hugo"]
+# download hugo and make it available in PATH
+ENV HUGO_VERSION 0.81.0
+ENV HUGO_BINARY hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
+
+ENV GLIBC_VERSION 2.23-r3
+
+RUN set -x && \
+  apk add --update wget ca-certificates libstdc++
+
+# Install glibc
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+&&  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+&&  apk --no-cache add glibc-${GLIBC_VERSION}.apk \
+&&  rm glibc-${GLIBC_VERSION}.apk \
+&&  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk \
+&&  apk --no-cache add glibc-bin-${GLIBC_VERSION}.apk \
+&&  rm glibc-bin-${GLIBC_VERSION}.apk \
+&&  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-i18n-${GLIBC_VERSION}.apk \
+&&  apk --no-cache add glibc-i18n-${GLIBC_VERSION}.apk \
+&&  rm glibc-i18n-${GLIBC_VERSION}.apk
+
+# Install HUGO
+
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} && \
+  tar xzf ${HUGO_BINARY} && \
+  rm -r ${HUGO_BINARY} && \
+  mv hugo /usr/bin && \
+  apk del wget ca-certificates && \
+  rm /var/cache/apk/*
+
+# Move site content to nginx
+
+RUN cp -fR /build/public/* /usr/share/nginx/html

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,124 @@
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    include       /etc/nginx/pagespeed.conf;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        #charset koi8-r;
+
+        #access_log  logs/host.access.log  main;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   html;
+        }
+
+        location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+" {
+            add_header "" "";
+        }
+        location ~ "^/pagespeed_static/" { }
+        location ~ "^/ngx_pagespeed_beacon$" { }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+
+    # another virtual host using mix of IP-, name-, and port-based configuration
+    #
+    #server {
+    #    listen       8000;
+    #    listen       somename:8080;
+    #    server_name  somename  alias  another.alias;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+
+    # HTTPS server
+    #
+    #server {
+    #    listen       443 ssl;
+    #    server_name  localhost;
+
+    #    ssl_certificate      cert.pem;
+    #    ssl_certificate_key  cert.key;
+
+    #    ssl_session_cache    shared:SSL:1m;
+    #    ssl_session_timeout  5m;
+
+    #    ssl_ciphers  HIGH:!aNULL:!MD5;
+    #    ssl_prefer_server_ciphers  on;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+}

--- a/conf/pagespeed.conf
+++ b/conf/pagespeed.conf
@@ -1,0 +1,33 @@
+pagespeed on;
+# Pagespeed Disallow "/admin*";
+pagespeed FileCachePath "/tmp/pagespeed_cache/";
+pagespeed FileCacheSizeKb 102400;
+pagespeed FileCacheCleanIntervalMs 3600000;
+pagespeed FileCacheInodeLimit 50000;
+pagespeed EnableCachePurge on;
+pagespeed PurgeMethod PURGE;
+pagespeed RewriteLevel CoreFilters;
+# core filters
+pagespeed EnableFilters add_head;
+pagespeed EnableFilters remove_quotes;
+pagespeed EnableFilters combine_css;
+pagespeed EnableFilters combine_javascript;
+pagespeed EnableFilters rewrite_images;
+# extra
+pagespeed EnableFilters insert_dns_prefetch;
+# WARN - nginx: [warn] [ngx_pagespeed 1.11.33.3-0] [0315/082307:WARNING:google_message_handler.cc(56)] Invalid filter name: hint_preload_subresources
+# pagespeed EnableFilters hint_preload_subresources; 
+pagespeed DisableFilters prioritize_critical_css;
+pagespeed EnableFilters sprite_images;
+pagespeed EnableFilters collapse_whitespace;
+pagespeed EnableFilters dedup_inlined_images;
+pagespeed EnableFilters inline_preview_images,resize_mobile_images;
+pagespeed EnableFilters lazyload_images;
+pagespeed EnableFilters rewrite_javascript;
+pagespeed EnableFilters responsive_images,resize_images;
+pagespeed FetchHttps enable;
+# location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+" {
+    # add_header "" "";
+# }
+# location ~ "^/pagespeed_static/" { }
+# location ~ "^/ngx_pagespeed_beacon$" { }


### PR DESCRIPTION
CLOSE https://github.com/ortelius/ortelius/issues/224

Following https://backbeat.tech/blog/static-site-docker-images and [pagespeed options](https://www.optiweb.com/blog/install-and-configure-nginx-pagespeed-module-for-better-performance/). Might need to configure PageSpeed.conf options.

I did not include `npm instal`l layer as I'm not sure if we need it inside the docker image because `HUGO` extended version already takes care of PostCSS and nothing seems to break without it.

To run:
```
docker build -t ortelius-static-site .

docker run -it -p 8000:80 ortelius-static-site
# site will be available at port 8000
```


