### PR TITLE
Upgrade build stage to use node:lts-alpine3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base nginx image
-FROM node:alpine as build
+FROM node:lts-alpine3.13 as build
 
 # an arbitrary directory to build our site in
 WORKDIR /build


### PR DESCRIPTION
Resolves: https://github.com/ortelius/ortelius/issues/246

The version of hugo available in the apk repos for our current node builder image is out of date (0.6.x). As a result, we're seeing a bug on ortelius.io around draft: true support for directories.

Updating the node image to  lts-alpine3.13 gives us access to a more recent version of hugo with support for draft directories.