### PR TITLE
Update blog summary blog to have consistent header image loading across levels

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -10,9 +10,7 @@
     {{ partial "hero" . }}
     <div class="container-fluid td-default td-outer">
       <main role="main" class="td-main">
-        {{ if eq .IsSection true}}
-          {{ partial "summary_block.html" . }}
-        {{ end }}
+        {{ partial "summary_block.html" .FirstSection }}
         <div class="row flex-xl-nowrap">
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}


### PR DESCRIPTION
Currently the blog section of the site loads the summary image with content for the top level, the header without content for the category level, and no header image for the posts themselves.

Quick change to have all sections of the blog load the top level summary information.
