### PR TITLE
Fixed Issue#442 (as part of Hacktoberfest)

### DIFF
--- a/content/en/contributor/_index.md
+++ b/content/en/contributor/_index.md
@@ -66,7 +66,7 @@ Don’t be shy, schedule a call with [Steve Taylor](https://go.oncehub.com/Steve
 {{< blocks/feature_dual >}}
 # Getting Started Resources
 - [Ortelius Contributor and User Documentation](https://docs.ortelius.io/guides/)
-- [Sign-up and learn Ortelius](https://www.deployhub.com/register-for-team/)
+- [Sign-up and learn Ortelius](https://www.deployhub.com/register-for-team)
 - [Ortelius YouTube Channel](https://www.youtube.com/channel/UCw2LfF0mqkaXdvqfVnIPWmw)
 
 # Learn About Open Source


### PR DESCRIPTION
At the end of URL, there was an additional slash breaking the link.